### PR TITLE
fixed some Hungarian phrase (e.g. '.' character translation).

### DIFF
--- a/src/main/res/values-hu/strings.xml
+++ b/src/main/res/values-hu/strings.xml
@@ -101,7 +101,7 @@
     <string name="title_pref_phonetic_letters" msgid="4315025096187253577">"Fonetikus betűk kimondása"</string>
     <string name="summaryOff_pref_phonetic_letters" msgid="2801720386630515717">"A fonetikus betűk nem lesznek kimondva."</string>
     <string name="summaryOn_pref_phonetic_letters" msgid="5160990473747883750">"A fonetikus betűk akkor lesznek kimondva, ha hosszan lenyomva tartja a billentyűzetet, és karakterenként halad."</string>
-    <string name="title_pref_a11y_hints" msgid="3770770318417664565">"Használata tippek kimondása"</string>
+    <string name="title_pref_a11y_hints" msgid="3770770318417664565">"Használati tippek kimondása"</string>
     <string name="summaryOff_pref_a11y_hints" msgid="6029151926582783201">"A használati tippek nem lesznek hangosan kimondva lineáris navigáció során."</string>
     <string name="summaryOn_pref_a11y_hints" msgid="8643053313815297483">"A használati tippek akkor lesznek kimondva – egy kis késéssel –, miután fókuszt vált lineáris navigáció esetén."</string>
     <string name="title_pref_explore_by_touch" msgid="1836003265647871107">"Felfedezés érintéssel"</string>

--- a/src/main/res/values-hu/symbols.xml
+++ b/src/main/res/values-hu/symbols.xml
@@ -33,7 +33,7 @@
     <string name="symbol_parenthesis_left" msgid="6800146954886245634">"Bal zárójel"</string>
     <string name="symbol_parenthesis_right" msgid="7215651695123277015">"Jobb zárójel"</string>
     <string name="symbol_percent" msgid="5459242644598387133">"Százalék"</string>
-    <string name="symbol_period" msgid="5437120137086222612">"Időszak"</string>
+    <string name="symbol_period" msgid="5437120137086222612">"Pont"</string>
     <string name="symbol_pi" msgid="9110332441949361829">"Pi"</string>
     <string name="symbol_pound" msgid="93826676999305096">"Kettős kereszt"</string>
     <string name="symbol_pound_sterling" msgid="728725055605726481">"Font"</string>


### PR DESCRIPTION
Dear developers,
In the Hungarian Talkback translation, the '.' character translation was incorrect. If you can, please merge my fixes to your code.
Thanks!