### PR TITLE
Voice markup

### DIFF
--- a/compositor/src/main/java/Compositor.java
+++ b/compositor/src/main/java/Compositor.java
@@ -206,6 +206,8 @@ public class Compositor {
   static final int ENUM_RANGE_INFO_TYPE = 6;
   static final int RANGE_INFO_UNDEFINED = -1;
 
+  private static final int ENUM_VOICE_TYPE = 7;
+
   // Enum values
   private static final int QUEUE_MODE_INTERRUPTIBLE_IF_LONG = 0x40000001;
 
@@ -224,6 +226,23 @@ public class Compositor {
   public static final int DESC_ORDER_ROLE_NAME_STATE_POSITION = 0;
   public static final int DESC_ORDER_STATE_NAME_ROLE_POSITION = 1;
   public static final int DESC_ORDER_NAME_ROLE_STATE_POSITION = 2;
+
+  /** Voice type ids. */
+  @IntDef({
+    VOICE_TYPE_LOW,
+    VOICE_TYPE_REDUCED,
+    VOICE_TYPE_NORMAL,
+    VOICE_TYPE_ELEVATED,
+    VOICE_TYPE_HIGH
+  })
+  @Retention(RetentionPolicy.SOURCE)
+  public @interface VoiceType {}
+
+  public static final int VOICE_TYPE_LOW = 0;
+  public static final int VOICE_TYPE_REDUCED = 1;
+  public static final int VOICE_TYPE_NORMAL = 2;
+  public static final int VOICE_TYPE_ELEVATED = 3;
+  public static final int VOICE_TYPE_HIGH = 4;
 
   /////////////////////////////////////////////////////////////////////////////////
   // Member variables
@@ -257,6 +276,9 @@ public class Compositor {
     boolean mSpeakRoles = true;
     boolean mSpeakCollectionInfo = true;
     @DescriptionOrder int mDescriptionOrder = DESC_ORDER_ROLE_NAME_STATE_POSITION;
+    @VoiceType int mActionableElementVoice = VOICE_TYPE_NORMAL;
+    @VoiceType int mButtonVoice = VOICE_TYPE_NORMAL;
+    @VoiceType int mImageVoice = VOICE_TYPE_NORMAL;
     boolean mSpeakElementIds = false;
   }
 
@@ -321,6 +343,27 @@ public class Compositor {
   public void setDescriptionOrder(@DescriptionOrder int descOrderInt) {
     if (descOrderInt != mConstants.mDescriptionOrder) {
       mConstants.mDescriptionOrder = descOrderInt;
+      mParseTreeIsStale = true;
+    }
+  }
+
+  public void setActionableElementVoice(@VoiceType int voiceType) {
+    if (voiceType != mConstants.mActionableElementVoice) {
+      mConstants.mActionableElementVoice = voiceType;
+      mParseTreeIsStale = true;
+    }
+  }
+
+  public void setButtonVoice(@VoiceType int voiceType) {
+    if (voiceType != mConstants.mButtonVoice) {
+      mConstants.mButtonVoice = voiceType;
+      mParseTreeIsStale = true;
+    }
+  }
+
+  public void setImageVoice(@VoiceType int voiceType) {
+    if (voiceType != mConstants.mImageVoice) {
+      mConstants.mImageVoice = voiceType;
       mParseTreeIsStale = true;
     }
   }
@@ -683,6 +726,18 @@ public class Compositor {
         "VERBOSITY_DESCRIPTION_ORDER",
         ENUM_VERBOSITY_DESCRIPTION_ORDER,
         constants.mDescriptionOrder);
+    parseTree.setConstantEnum(
+        "ACTIONABLE_ELEMENT_VOICE",
+        ENUM_VOICE_TYPE,
+        constants.mActionableElementVoice);
+    parseTree.setConstantEnum(
+        "BUTTON_VOICE",
+        ENUM_VOICE_TYPE,
+        constants.mButtonVoice);
+    parseTree.setConstantEnum(
+        "IMAGE_VOICE",
+        ENUM_VOICE_TYPE,
+        constants.mImageVoice);
     parseTree.setConstantBool("VERBOSITY_SPEAK_ELEMENT_IDS", constants.mSpeakElementIds);
   }
 
@@ -772,6 +827,14 @@ public class Compositor {
     verbosityDescOrderValues.put(DESC_ORDER_STATE_NAME_ROLE_POSITION, "StateNameRolePosition");
     verbosityDescOrderValues.put(DESC_ORDER_NAME_ROLE_STATE_POSITION, "NameRoleStatePosition");
     parseTree.addEnum(ENUM_VERBOSITY_DESCRIPTION_ORDER, verbosityDescOrderValues);
+
+    Map<Integer, String> voiceTypeValues = new HashMap<>();
+    voiceTypeValues.put(VOICE_TYPE_LOW, "low");
+    voiceTypeValues.put(VOICE_TYPE_REDUCED, "reduced");
+    voiceTypeValues.put(VOICE_TYPE_NORMAL, "normal");
+    voiceTypeValues.put(VOICE_TYPE_ELEVATED, "elevated");
+    voiceTypeValues.put(VOICE_TYPE_HIGH, "high");
+    parseTree.addEnum(ENUM_VOICE_TYPE, voiceTypeValues);
 
     Map<Integer, String> rangeInfoTypes = new HashMap<>();
     rangeInfoTypes.put(RangeInfo.RANGE_TYPE_INT, "int");

--- a/compositor/src/main/res/raw/compositor.json
+++ b/compositor/src/main/res/raw/compositor.json
@@ -209,6 +209,7 @@
         "then":"queue",
         "else":"flush"
       },
+      "ttsPitch": "%get_voice_for_element",
       "ttsAddToHistory": true,
       // TODO: Remove the next line when focus management feature is settled down.
       //"ttsForceFeedback": "!$global.syncedAccessibilityFocusLatch && $node.role != 'web_view'",
@@ -242,6 +243,7 @@
     },
     "TYPE_VIEW_FOCUSED": {
       "ttsOutput": "%event_description",
+      "ttsPitch": "%get_voice_for_element",
       "ttsAddToHistory": true,
       // From FallbackFormatter
       // TODO: Delete porting comments.
@@ -256,6 +258,7 @@
     },
     "TYPE_VIEW_HOVER_ENTER": {
       "ttsOutput": "%event_description",
+      "ttsPitch": "%get_voice_for_element",
       "ttsAddToHistory": true,
       // TODO: respect user settings
       "ttsForceFeedbackAudioPlaybackActive": true,
@@ -1799,6 +1802,54 @@
           }
         }
       ]
-    }
+    },
+    "get_voice_for_element": {
+      "switch": "$node.role",
+      "cases": {
+        "button": "%button_voice",
+        "image_button": "%button_voice",
+        "image": "%image_voice"
+      },
+      "default": {
+        "if": "$node.isActionable",
+        "then": "%actionable_element_voice",
+        "else": "%voice_normal"
+      }
+    },
+    "actionable_element_voice": {
+      "switch": "#ACTIONABLE_ELEMENT_VOICE",
+      "cases": {
+        "low": "%voice_low",
+        "reduced": "%voice_reduced",
+        "normal": "%voice_normal",
+        "elevated": "%voice_elevated",
+        "high": "%voice_high"
+      }
+    },
+    "button_voice": {
+      "switch": "#BUTTON_VOICE",
+      "cases": {
+        "low": "%voice_low",
+        "reduced": "%voice_reduced",
+        "normal": "%voice_normal",
+        "elevated": "%voice_elevated",
+        "high": "%voice_high"
+      }
+    },
+    "image_voice": {
+      "switch": "#IMAGE_VOICE",
+      "cases": {
+        "low": "%voice_low",
+        "reduced": "%voice_reduced",
+        "normal": "%voice_normal",
+        "elevated": "%voice_elevated",
+        "high": "%voice_high"
+      }
+    },
+    "voice_low": 0.6,
+    "voice_reduced": 0.8,
+    "voice_normal": 1.0,
+    "voice_elevated": 1.25,
+    "voice_high": 1.5
   }
 }

--- a/talkback/src/main/java/TalkBackService.java
+++ b/talkback/src/main/java/TalkBackService.java
@@ -1878,6 +1878,18 @@ public class TalkBackService extends AccessibilityService
               prefs, res, R.string.pref_node_desc_order_key, R.string.pref_node_desc_order_default);
       compositor.setDescriptionOrder(prefValueToDescriptionOrder(res, descriptionOrder));
 
+      // Update voice markup preferences.
+      String voiceType =
+          SharedPreferencesUtils.getStringPref(
+              prefs, res, R.string.pref_button_voice_key, R.string.pref_voice_default);
+      compositor.setButtonVoice(prefValueToVoiceType(res, voiceType));
+      voiceType = SharedPreferencesUtils.getStringPref(
+              prefs, res, R.string.pref_image_voice_key, R.string.pref_voice_default);
+      compositor.setImageVoice(prefValueToVoiceType(res, voiceType));
+      voiceType = SharedPreferencesUtils.getStringPref(
+              prefs, res, R.string.pref_actionable_voice_key, R.string.pref_voice_default);
+      compositor.setActionableElementVoice(prefValueToVoiceType(res, voiceType));
+
       // Update preference: speak element IDs.
       boolean speakElementIds =
           SharedPreferencesUtils.getBooleanPref(
@@ -1916,6 +1928,24 @@ public class TalkBackService extends AccessibilityService
       LogUtils.e(TAG, "Unhandled description order preference value \"%s\"", value);
       return Compositor.DESC_ORDER_STATE_NAME_ROLE_POSITION;
     }
+  }
+
+  private static @Compositor.VoiceType int prefValueToVoiceType(
+      Resources resources, String value) {
+    if (TextUtils.equals(
+        value, resources.getString(R.string.voice_type_low_pitch))) {
+      return Compositor.VOICE_TYPE_LOW;
+    } else if (TextUtils.equals(
+        value, resources.getString(R.string.voice_type_reduced_pitch))) {
+      return Compositor.VOICE_TYPE_REDUCED;
+    } else if (TextUtils.equals(
+        value, resources.getString(R.string.voice_type_elevated_pitch))) {
+      return Compositor.VOICE_TYPE_ELEVATED;
+    } else if (TextUtils.equals(
+        value, resources.getString(R.string.voice_type_high_pitch))) {
+      return Compositor.VOICE_TYPE_HIGH;
+    }
+    return Compositor.VOICE_TYPE_NORMAL;
   }
 
   /**

--- a/talkback/src/main/res/values-ru/strings.xml
+++ b/talkback/src/main/res/values-ru/strings.xml
@@ -523,4 +523,21 @@
   <string name="hint_type_search_term">Введите поисковый запрос</string>
   <string name="talkback_notification_channel_name">TalkBack</string>
   <string name="talkback_notification_channel_description">Канал уведомлений TalkBack</string>
+
+  <!-- Voice types -->
+  <string name="low_pitch_voice">Низкий</string>
+  <string name="reduced_pitch_voice">Пониженный</string>
+  <string name="normal_voice">Нормальный</string>
+  <string name="elevated_pitch_voice">Повышенный</string>
+  <string name="high_pitch_voice">Высокий</string>
+
+  <!-- For voice markup preferences -->
+  <string name="pref_verbosity_category_voice_markup_settings_title">Голоса для различных элементов</string>
+  <string name="pref_button_voice_dialog_title">Голос для озвучивания кнопок</string>
+  <string name="pref_button_voice_title">Кнопки</string>
+  <string name="pref_image_voice_dialog_title">Голос для озвучивания изображений</string>
+  <string name="pref_image_voice_title">Изображения</string>
+  <string name="pref_actionable_voice_dialog_title">Голос для озвучивания активных элементов</string>
+  <string name="pref_actionable_voice_title">Активные элементы</string>
+
 </resources>

--- a/talkback/src/main/res/values/donottranslate.xml
+++ b/talkback/src/main/res/values/donottranslate.xml
@@ -585,4 +585,31 @@
 
     <string name="pref_key_last_log_time_key">pref_key_last_log_time_key</string>
 
+    <!-- Voice type preferences. Matches Compositor.VoiceType -->
+    <string-array name="pref_voice_entries">
+        <item>@string/low_pitch_voice</item>
+        <item>@string/reduced_pitch_voice</item>
+        <item>@string/normal_voice</item>
+        <item>@string/elevated_pitch_voice</item>
+        <item>@string/high_pitch_voice</item>
+    </string-array>
+    <string-array name="pref_voice_values">
+        <item>@string/voice_type_low_pitch</item>
+        <item>@string/voice_type_reduced_pitch</item>
+        <item>@string/voice_type_normal</item>
+        <item>@string/voice_type_elevated_pitch</item>
+        <item>@string/voice_type_high_pitch</item>
+    </string-array>
+    <string name="voice_type_low_pitch">low_pitch</string>
+    <string name="voice_type_reduced_pitch">reduced_pitch</string>
+    <string name="voice_type_normal">normal</string>
+    <string name="voice_type_elevated_pitch">elevated_pitch</string>
+    <string name="voice_type_high_pitch">high_pitch</string>
+    <string name="pref_voice_default">@string/voice_type_normal</string>
+
+    <!-- Voice markup preferences keys -->
+    <string name="pref_actionable_voice_key">actionable_voice_pitch</string>
+    <string name="pref_image_voice_key">image_voice_pitch</string>
+    <string name="pref_button_voice_key">button_voice_pitch</string>
+
 </resources>

--- a/talkback/src/main/res/values/strings.xml
+++ b/talkback/src/main/res/values/strings.xml
@@ -1518,4 +1518,20 @@
   <!-- Notification channel description of Talkback. [CHAR_LIMIT=42] -->
   <string name="talkback_notification_channel_description">The Notification Channel of TalkBack</string>
 
+  <!-- Voice types -->
+  <string name="low_pitch_voice">Low pitch</string>
+  <string name="reduced_pitch_voice">Reduced pitch</string>
+  <string name="normal_voice">Normal</string>
+  <string name="elevated_pitch_voice">Elevated pitch</string>
+  <string name="high_pitch_voice">High pitch</string>
+
+  <!-- For voice markup preferences -->
+  <string name="pref_verbosity_category_voice_markup_settings_title">Voices for various elements</string>
+  <string name="pref_button_voice_dialog_title">Voice for speaking buttons</string>
+  <string name="pref_button_voice_title">Buttons</string>
+  <string name="pref_image_voice_dialog_title">Voice for speaking images</string>
+  <string name="pref_image_voice_title">Images</string>
+  <string name="pref_actionable_voice_dialog_title">Voice for speaking actionable elements</string>
+  <string name="pref_actionable_voice_title">Actionable elements</string>
+
 </resources>

--- a/talkback/src/main/res/xml/verbosity_preferences.xml
+++ b/talkback/src/main/res/xml/verbosity_preferences.xml
@@ -84,6 +84,41 @@
 
   </PreferenceCategory>
 
+  <!-- Voice markup settings -->
+  <PreferenceCategory android:title="@string/pref_verbosity_category_voice_markup_settings_title">
+
+    <!-- Voice for buttons -->
+    <ListPreference
+        android:defaultValue="@string/pref_voice_default"
+        android:dialogTitle="@string/pref_button_voice_dialog_title"
+        android:entries="@array/pref_voice_entries"
+        android:entryValues="@array/pref_voice_values"
+        android:key="@string/pref_button_voice_key"
+        android:summary="%s"
+        android:title="@string/pref_button_voice_title" />
+
+    <!-- Voice for images -->
+    <ListPreference
+        android:defaultValue="@string/pref_voice_default"
+        android:dialogTitle="@string/pref_image_voice_dialog_title"
+        android:entries="@array/pref_voice_entries"
+        android:entryValues="@array/pref_voice_values"
+        android:key="@string/pref_image_voice_key"
+        android:summary="%s"
+        android:title="@string/pref_image_voice_title" />
+
+    <!-- Voice for actionable elements -->
+    <ListPreference
+        android:defaultValue="@string/pref_voice_default"
+        android:dialogTitle="@string/pref_actionable_voice_dialog_title"
+        android:entries="@array/pref_voice_entries"
+        android:entryValues="@array/pref_voice_values"
+        android:key="@string/pref_actionable_voice_key"
+        android:summary="%s"
+        android:title="@string/pref_actionable_voice_title" />
+
+  </PreferenceCategory>
+
   <!-- Non-preset detailed settings -->
   <PreferenceCategory android:title="@string/pref_verbosity_category_misc_settings_title">
 


### PR DESCRIPTION
Just an idea. It seems, user interactions would be noticeably more
effective if there was a capability to assign different voices for
speaking elements of different types, for instance, changing voice
pitch. Such changes are detected instantly, thus, listening to an
element content, user would already know its role. It is especially
valuable when browsing web pages.

Of course, earcons serve just the same purpose and they really help in
many cases, but not everywhere. On the other hand, when user attention
is concentrated on a content, voice pitch changes generally have less
chances to be overlooked.
