### PR TITLE
Cursor movement feedback fix in editable fields

### DIFF
--- a/compositor/src/main/java/TextEventInterpreter.java
+++ b/compositor/src/main/java/TextEventInterpreter.java
@@ -362,8 +362,13 @@ public class TextEventInterpreter {
         interpretation.setEvent(Compositor.EVENT_TYPE_INPUT_SELECTION_MOVE_CURSOR_NO_SELECTION);
         interpretation.setReason("Cursor moved to end of selection.");
         // Extract traversed text.
-        int startIndex = Math.min(mHistory.getLastToIndex(), toIndex);
-        int endIndex = Math.max(mHistory.getLastToIndex(), toIndex);
+        /*
+         * Actually it is better to get a character under cursor here.
+         */
+        int startIndex = currentCursorPos;
+        int endIndex = currentCursorPos;
+        if (currentCursorPos != previousCursorPos)
+            endIndex++;
         if (0 <= startIndex && endIndex <= textLength) {
           CharSequence traversedText = getSubsequence(isPassword, text, startIndex, endIndex);
           interpretation.setTraversedText(traversedText);


### PR DESCRIPTION
When cursor is moved through an editable field, user should be
informed about its current position, i.e. a symbol just under cursor,
rather than about traversed text. Current strategy, based on the
traversed text, in fact, introduces an ambiguity. Assume, I move
cursor back and forth through a text searching for a wrong
symbol. After a backward movement cursor points to the symbol it just
have traversed and it is announced. If it is the symbol I search for,
I press delete. Moving forward, cursor traverses symbol just before
its position after movement, so this symbol is announced. But I must
take in account that it is not the symbol under cursor, but the one
just before it.
