### PR TITLE
Update buils script path to cmd line tools.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ log
 
 
 log "Accept SDK licenses"
-yes | "${ANDROID_SDK}"/tools/bin/sdkmanager --licenses
+yes | "${ANDROID_SDK}"/cmdline-tools/latest/bin/sdkmanager --licenses
 log
 
 


### PR DESCRIPTION
### Objective
* Update the build script to match the new location of the command line tools.

### Description
* Originally these were located in `{ANDROID_SDK}"/tools/bin/` but have been since moved to `{ANDROID_SDK}"/cmdline-tools/latest/bin/`