### PR TITLE
Update build.sh to use cmdline tools.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ log
 
 
 log "Accept SDK licenses"
-log "${ANDROID_SDK}"/tools/bin/sdkmanager --licenses; yes | "${ANDROID_SDK}"/tools/bin/sdkmanager --licenses
+log "${ANDROID_SDK}"/cmdline-tools/latest/bin/sdkmanager --licenses; yes | "${ANDROID_SDK}"/cmdline-tools/latest/bin/sdkmanager --licenses
 ACCEPT_SDK_LICENSES_EXIT_CODE=$?
 log
 if [[ $ACCEPT_SDK_LICENSES_EXIT_CODE -ne 0 ]]; then


### PR DESCRIPTION
### Objective
* Fix the simple out of the box experience when cloning TalkBack and then running "./build.sh" on any recent version of Android Tools/Android Studio.

### Description
* The sdkmanager located in  `{ANDROID_SDK}"/tools/bin/` contains an old-unmaintained version of the sdk manager that doesn't work with the version of JAVA shipped in modern Android Studio versions. 
* The "new" _more updated_ `sdkmanager` is located in `{ANDROID_SDK}"/cmdline-tools/latest/bin/sdkmanager`.
* It is expected that new Android Devs who have not downloaded this _Optional_ dependency, can do so with one click (and they can, by using the SDK Manager included in their Android Studio. This is better than a cryptic error message like `Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema` when running a build script.

