### PR TITLE
Update build.sh to use sdkmanager from command line tools for licensing 

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ log
 
 
 log "Accept SDK licenses"
-log "${ANDROID_SDK}"/tools/bin/sdkmanager --licenses; yes | "${ANDROID_SDK}"/tools/bin/sdkmanager --licenses
+log "${ANDROID_SDK}"//cmdline-tools/latest/bin/sdkmanager --licenses; yes | "${ANDROID_SDK}"/cmdline-tools/latest/bin/sdkmanager --licenses
 ACCEPT_SDK_LICENSES_EXIT_CODE=$?
 log
 if [[ $ACCEPT_SDK_LICENSES_EXIT_CODE -ne 0 ]]; then


### PR DESCRIPTION
Fixes

Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
	at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
	at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
	at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)