### PR TITLE
Fix silent skip of multiple nodes during linear navigation after a large auto-scroll

### DIFF
--- a/utils/src/main/java/com/google/android/accessibility/utils/traversal/OrderedTraversalController.java
+++ b/utils/src/main/java/com/google/android/accessibility/utils/traversal/OrderedTraversalController.java
@@ -16,6 +16,8 @@
 
 package com.google.android.accessibility.utils.traversal;
 
+import android.content.res.Resources;
+import android.graphics.Rect;
 import androidx.annotation.NonNull;
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import com.google.android.accessibility.utils.AccessibilityNodeInfoUtils;
@@ -237,8 +239,12 @@ public class OrderedTraversalController {
   public @Nullable AccessibilityNodeInfoCompat findNext(AccessibilityNodeInfoCompat node) {
     WorkingTree tree = nodeTreeMap.get(node);
     if (tree == null) {
-      LogUtils.w(TAG, "findNext(), can't find WorkingTree for AccessibilityNodeInfo");
-      return null;
+      LogUtils.w(
+          TAG,
+          "findNext(), can't find WorkingTree for AccessibilityNodeInfo; falling back to"
+              + " topmost visible node");
+      WorkingTree fallback = findVisibleEdgeWorkingTree(/* forward= */ true);
+      return (fallback == null) ? null : fallback.getNode();
     }
 
     WorkingTree nextTree = tree.getNext();
@@ -252,8 +258,12 @@ public class OrderedTraversalController {
   public @Nullable AccessibilityNodeInfoCompat findPrevious(AccessibilityNodeInfoCompat node) {
     WorkingTree tree = nodeTreeMap.get(node);
     if (tree == null) {
-      LogUtils.w(TAG, "findPrevious(), can't find WorkingTree for AccessibilityNodeInfo");
-      return null;
+      LogUtils.w(
+          TAG,
+          "findPrevious(), can't find WorkingTree for AccessibilityNodeInfo; falling back to"
+              + " bottommost visible node");
+      WorkingTree fallback = findVisibleEdgeWorkingTree(/* forward= */ false);
+      return (fallback == null) ? null : fallback.getNode();
     }
 
     WorkingTree prevTree = tree.getPrevious();
@@ -262,6 +272,38 @@ public class OrderedTraversalController {
     }
 
     return null;
+  }
+
+  /**
+   * Fallback used when the search pivot node is no longer present in {@link #nodeTreeMap} (e.g.
+   * its underlying view was recycled by the app after a large or multi-step auto-scroll, possibly
+   * across a list that is itself growing via pagination). The pivot's last-known on-screen bounds
+   * are stale once a scroll like that has happened, so comparing them against the freshly-queried
+   * bounds of nodes in the rebuilt tree is unreliable. Instead, this picks the node currently
+   * nearest to the relevant edge of the visible viewport -- the topmost visible node for {@code
+   * forward} (the first thing the user would now encounter reading down), or the bottommost
+   * visible node otherwise -- which is invariant to how far or in how many steps the scroll
+   * actually moved.
+   */
+  private @Nullable WorkingTree findVisibleEdgeWorkingTree(boolean forward) {
+    int screenHeight = Resources.getSystem().getDisplayMetrics().heightPixels;
+
+    WorkingTree best = null;
+    int bestEdge = forward ? Integer.MAX_VALUE : Integer.MIN_VALUE;
+    for (Map.Entry<AccessibilityNodeInfoCompat, WorkingTree> entry : nodeTreeMap.entrySet()) {
+      Rect bounds = new Rect();
+      entry.getKey().getBoundsInScreen(bounds);
+      // Skip nodes that aren't actually on screen (e.g. still attached but scrolled fully out of
+      // the viewport).
+      if (bounds.bottom <= 0 || bounds.top >= screenHeight) {
+        continue;
+      }
+      if (forward ? (bounds.top < bestEdge) : (bounds.bottom > bestEdge)) {
+        bestEdge = forward ? bounds.top : bounds.bottom;
+        best = entry.getValue();
+      }
+    }
+    return best;
   }
 
   /** Searches first node to be focused */


### PR DESCRIPTION
## Summary

`OrderedTraversalController.findNext()` / `findPrevious()` return `null` whenever the search pivot node is no longer present in the freshly rebuilt `nodeTreeMap` (e.g. its underlying view was recycled by the app after a large or multi-step auto-scroll, including on lists that grow via pagination while scrolling). Callers then fall back to a coarser whole-tree search, which can land focus many items away from the correct next/previous node — silently skipping everything in between without ever announcing it.

## Repro

Reproduced with TalkBack's own verbose ("Diagnosis mode") logging while reading articles in the NOS news app (`nl.nos.app`, a mainstream Dutch news app): a single forward swipe from a paragraph would sometimes skip a dozen subsequent paragraphs, headings and a pull-quote in one go, landing on unrelated content much further down the screen. The same skip (of a different size each time) also reproduced in that app's article list while scrolling through cards.

Backward navigation through the exact same content worked correctly every time, which narrows the fault to this forward/backward "find next focusable node" path rather than to how the content is exposed to accessibility services by the app.

Log excerpt showing the failure point:
```
OrderedTraversalCont: findNext(), can't find WorkingTree for AccessibilityNodeInfo
```
immediately following a single `ACTION_SCROLL_FORWARD` that moved a RecyclerView from `scrollY=0` to `scrollY=3814` of `maxScrollY=3914` (~97% of the whole list) in one step.

I also wrote up a fuller repro report (two independent article examples, screenshots, and this log analysis) via TalkBack's in-app "Help & feedback" tool.

## Fix

Patches `findNext()`/`findPrevious()` to fall back to the node nearest the relevant edge of the current visible viewport (topmost for forward, bottommost for backward) when the pivot lookup misses, instead of returning `null`. This is invariant to how far or in how many steps the triggering scroll actually moved.

An earlier version of this fix compared against the pivot's stale pre-scroll screen coordinates instead; that worked for the article-text case but broke on the article list, where pagination/infinite-scroll shifts coordinates across multiple scroll events during a single navigation action. The viewport-edge approach doesn't depend on the stale coordinates at all.

## Testing

Built and installed on a secondary device (side-by-side with the Play Store TalkBack, since this open-source build already uses a different `applicationId`). With Diagnosis mode logging on, stepped through both a NOS article (crossing an embedded image partway through) and the NOS article list, one swipe at a time, in both directions. Confirmed the new fallback path fires (visible in the log) and resolves to the correct adjacent node every time, where it previously landed several items away.

## Open question

Not addressed here: why a single `ACTION_SCROLL_FORWARD` on the affected `RecyclerView`/Compose list scrolls so far (up to ~97% of the list) in one step. That's outside TalkBack's own code, but it's the trigger that puts `findNext()`/`findPrevious()` into the failing state this PR handles.

I noticed a few actively-maintained TalkBack forks facing the same silent-skip symptom in their issue trackers; hopefully this is useful to them too, whether or not it lands here.