### PR TITLE
Add support for BraillePen24 HID

### DIFF
--- a/braille/brltty/src/phone/java/com/google/android/accessibility/braille/brltty/device/SupportedDeviceHid.java
+++ b/braille/brltty/src/phone/java/com/google/android/accessibility/braille/brltty/device/SupportedDeviceHid.java
@@ -14,7 +14,9 @@ import java.util.regex.Pattern;
 public class SupportedDeviceHid extends SupportedDevice {
   private static final String HID_STUB_DEVICE_NAME = "HID";
   private static final ImmutableList<Pattern> NAME_REGEXES =
-      ImmutableList.of(Pattern.compile(HID_STUB_DEVICE_NAME));
+      ImmutableList.of(
+              Pattern.compile(HID_STUB_DEVICE_NAME),
+              Pattern.compile("BP24-"));
 
   @Override
   public String driverCode() {
@@ -42,6 +44,12 @@ public class SupportedDeviceHid extends SupportedDevice {
         .add("DPadCenter", R.string.key_dpad_center)
         .add("RockerUp", R.string.key_rocker_up)
         .add("RockerDown", R.string.key_rocker_down)
+        .add("JoystickUp", R.string.key_JoystickUp)
+        .add("JoystickDown", R.string.key_JoystickDown)
+        .add("JoystickLeft", R.string.key_JoystickLeft)
+        .add("JoystickRight", R.string.key_JoystickRight)
+        .add("JoystickCenter", R.string.key_JoystickCenter)
+        .routing()
         .build();
   }
 

--- a/braille/brltty/src/phone/jni/brlttywrapper/third_party/brltty/Drivers/Braille/HID/brldefs-hid.h
+++ b/braille/brltty/src/phone/jni/brlttywrapper/third_party/brltty/Drivers/Braille/HID/brldefs-hid.h
@@ -67,6 +67,10 @@ int KEY_MAP[][2] = {
     {HID_USG_BRL_DPadDown, HID_KEY_DPadDown},
     {HID_USG_BRL_DPadLeft, HID_KEY_DPadLeft},
     {HID_USG_BRL_DPadRight, HID_KEY_DPadRight},
+    // BP24 internal pan keys.
+    // BP24 exposes them as Button usages 0x14 and 0x15.
+    {0x14, HID_KEY_DPadLeft},
+    {0x15, HID_KEY_DPadRight},
     {HID_USG_BRL_DPadCenter, HID_KEY_DPadCenter},
     {HID_USG_BRL_RockerUp, HID_KEY_RockerUp},
     {HID_USG_BRL_RockerDown, HID_KEY_RockerDown},


### PR DESCRIPTION
## Summary

This pull request adds support for the BraillePen24 Braille display using the HID protocol.

Tested with a physical BraillePen24 device.

## Changes

- Added BraillePen24 HID device definition.
- Added BraillePen24 device detection in `SupportedDeviceHid`.
- Added BraillePen24 HID report definitions in `brldefs-hid.h`.

## Testing

- Successfully built in Android Studio.
- Tested with a physical BraillePen24 device.
- Device is detected correctly and operates as expected.